### PR TITLE
Make caches that are outside the network reachable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,11 @@ services:
     - 8100:8100
     environment:
     - CACHECASH_INSECURE=true
+    # Configure the publisher origin to avoid CORS errors.
     - PUBLISHER_ORIGIN=http://localhost:1234
+    # If there is any cache running outside of a local network shared by the daemons,
+    # update the publisher address to include the IP address or domain name of
+    # the machine where the publisher is running to make the publisher reachable.
     - PUBLISHER_PUBLISHER_ADDR=publisher:7070
     - PUBLISHER_UPSTREAM=${PUBLISHER_UPSTREAM:-http://upstream:80}
     - PUBLISHER_BOOTSTRAP_ADDR=bootstrapd:7777
@@ -152,6 +156,8 @@ services:
   cache-0:
     image: cachecash/go-cachecash
     build: .
+    # If the cache runs outside of a local network shared by the jaeger and logpipe,
+    # replace jaeger:14268, and logpiped:9005 accordingly to reach them.
     command: cached -logLevel debug -trace http://jaeger:14268 -logAddress logpiped:9005
     ports:
     - 9000:9000
@@ -163,8 +169,15 @@ services:
     - CACHE_GRPC_ADDR=cache-0:9000
     - CACHE_HTTP_ADDR=cache-0:9443
     - CACHE_STATUS_ADDR=cache-0:7100
-    # - CACHE_CONTACT_URL=http://localhost
+    # If the cache does not run as part of a local network shared by the daemons,
+    # replace cache-0 with the IP address or domain name of the machine
+    # where the cache is running to make the cache reachable.
+    # - CACHE_CONTACT_URL=http://cache-0
+    # If the same situation above applies, change bootstrap, ledger, and metrics
+    # to include the IP address or domain name of the machine(s) where they are
+    # running to reach them.
     - CACHE_BOOTSTRAP_ADDR=bootstrapd:7777
+    - CACHE_LEDGER_ADDR=ledger:7778
     - CACHE_METRICS_ENDPOINT=metrics:8000
     volumes:
     - ./data/cache-0:/data
@@ -183,8 +196,9 @@ services:
     - CACHE_GRPC_ADDR=cache-1:9001
     - CACHE_HTTP_ADDR=cache-1:9444
     - CACHE_STATUS_ADDR=cache-1:7101
-    # - CACHE_CONTACT_URL=http://localhost
+    # - CACHE_CONTACT_URL=http://cache-1
     - CACHE_BOOTSTRAP_ADDR=bootstrapd:7777
+    - CACHE_LEDGER_ADDR=ledger:7778
     - CACHE_METRICS_ENDPOINT=metrics:8000
     volumes:
     - ./data/cache-1:/data
@@ -203,8 +217,9 @@ services:
     - CACHE_GRPC_ADDR=cache-2:9002
     - CACHE_HTTP_ADDR=cache-2:9445
     - CACHE_STATUS_ADDR=cache-2:7102
-    # - CACHE_CONTACT_URL=http://localhost
+    # - CACHE_CONTACT_URL=http://cache-2
     - CACHE_BOOTSTRAP_ADDR=bootstrapd:7777
+    - CACHE_LEDGER_ADDR=ledger:7778
     - CACHE_METRICS_ENDPOINT=metrics:8000
     volumes:
     - ./data/cache-2:/data
@@ -222,8 +237,9 @@ services:
     - CACHE_GRPC_ADDR=cache-3:9003
     - CACHE_HTTP_ADDR=cache-3:9446
     - CACHE_STATUS_ADDR=cache-3:7103
-    # - CACHE_CONTACT_URL=http://localhost
+    # - CACHE_CONTACT_URL=http://cache-3
     - CACHE_BOOTSTRAP_ADDR=bootstrapd:7777
+    - CACHE_LEDGER_ADDR=ledger:7778
     - CACHE_METRICS_ENDPOINT=metrics:8000
     volumes:
     - ./data/cache-3:/data
@@ -242,8 +258,9 @@ services:
     - CACHE_GRPC_ADDR=cache-4:9004
     - CACHE_HTTP_ADDR=cache-4:9447
     - CACHE_STATUS_ADDR=cache-4:7104
-    # - CACHE_CONTACT_URL=http://localhost
+    # - CACHE_CONTACT_URL=http://cache-4
     - CACHE_BOOTSTRAP_ADDR=bootstrapd:7777
+    - CACHE_LEDGER_ADDR=ledger:7778
     - CACHE_METRICS_ENDPOINT=metrics:8000
     volumes:
     - ./data/cache-4:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,7 @@ services:
     command: bootstrapd -logLevel debug -trace http://jaeger:14268
     environment:
     - CACHECASH_INSECURE=true
+    - BOOTSTRAP_PROXY_PROTOCOL=false
     ports:
     - 7777:7777
     # status
@@ -136,7 +137,7 @@ services:
   faucetd:
     image: cachecash/go-cachecash
     build: .
-    #command: faucetd -logLevel debug -trace http://jaeger:14268 -logAddress logpiped:9005
+    # command: faucetd -logLevel debug -trace http://jaeger:14268 -logAddress logpiped:9005
     command: faucetd -logLevel debug -keypair /ledger/ledger.keypair.json
     environment:
     - CACHECASH_INSECURE=true
@@ -156,9 +157,13 @@ services:
     - 9000:9000
     - 9443:9443
     # status
-    - 7100:9100
+    - 7100:7100
     environment:
     - CACHECASH_INSECURE=true
+    - CACHE_GRPC_ADDR=cache-0:9000
+    - CACHE_HTTP_ADDR=cache-0:9443
+    - CACHE_STATUS_ADDR=cache-0:7100
+    # - CACHE_CONTACT_URL=http://localhost
     - CACHE_BOOTSTRAP_ADDR=bootstrapd:7777
     - CACHE_METRICS_ENDPOINT=metrics:8000
     volumes:
@@ -169,12 +174,16 @@ services:
     build: .
     command: cached -logLevel debug -trace http://jaeger:14268 -logAddress logpiped:9005
     ports:
-    - 9001:9000
-    - 9444:9443
+    - 9001:9001
+    - 9444:9444
     # status
-    - 7101:9100
+    - 7101:7101
     environment:
     - CACHECASH_INSECURE=true
+    - CACHE_GRPC_ADDR=cache-1:9001
+    - CACHE_HTTP_ADDR=cache-1:9444
+    - CACHE_STATUS_ADDR=cache-1:7101
+    # - CACHE_CONTACT_URL=http://localhost
     - CACHE_BOOTSTRAP_ADDR=bootstrapd:7777
     - CACHE_METRICS_ENDPOINT=metrics:8000
     volumes:
@@ -185,12 +194,16 @@ services:
     build: .
     command: cached -logLevel debug -trace http://jaeger:14268 -logAddress logpiped:9005
     ports:
-    - 9002:9000
-    - 9445:9443
+    - 9002:9002
+    - 9445:9445
     # status
-    - 7102:9100
+    - 7102:7102
     environment:
     - CACHECASH_INSECURE=true
+    - CACHE_GRPC_ADDR=cache-2:9002
+    - CACHE_HTTP_ADDR=cache-2:9445
+    - CACHE_STATUS_ADDR=cache-2:7102
+    # - CACHE_CONTACT_URL=http://localhost
     - CACHE_BOOTSTRAP_ADDR=bootstrapd:7777
     - CACHE_METRICS_ENDPOINT=metrics:8000
     volumes:
@@ -201,11 +214,15 @@ services:
     build: .
     command: cached -logLevel debug -trace http://jaeger:14268 -logAddress logpiped:9005
     ports:
-    - 9003:9000
-    - 9446:9443
-    - 7103:9100
+    - 9003:9003
+    - 9446:9446
+    - 7103:7103
     environment:
     - CACHECASH_INSECURE=true
+    - CACHE_GRPC_ADDR=cache-3:9003
+    - CACHE_HTTP_ADDR=cache-3:9446
+    - CACHE_STATUS_ADDR=cache-3:7103
+    # - CACHE_CONTACT_URL=http://localhost
     - CACHE_BOOTSTRAP_ADDR=bootstrapd:7777
     - CACHE_METRICS_ENDPOINT=metrics:8000
     volumes:
@@ -216,12 +233,16 @@ services:
     build: .
     command: cached -logLevel debug -trace http://jaeger:14268 -logAddress logpiped:9005
     ports:
-    - 9004:9000
-    - 9447:9443
+    - 9004:9004
+    - 9447:9447
     # status
-    - 7104:9100
+    - 7104:7104
     environment:
     - CACHECASH_INSECURE=true
+    - CACHE_GRPC_ADDR=cache-4:9004
+    - CACHE_HTTP_ADDR=cache-4:9447
+    - CACHE_STATUS_ADDR=cache-4:7104
+    # - CACHE_CONTACT_URL=http://localhost
     - CACHE_BOOTSTRAP_ADDR=bootstrapd:7777
     - CACHE_METRICS_ENDPOINT=metrics:8000
     volumes:


### PR DESCRIPTION
In this pull request, you find three files updated for _bug fixing_, which makes the caches running outside the network **reachable**.

#### Update on the contact URL:
The only way for the `bootstrapd.go` file could define the source IP of a cache was to get the peer from the context. In this way, it can result in having a **private IP** address at self-managed on-premises machines. And that's why caches become unreachable. I put a code part that checks the form of the contact URL set by docker-compose file, and then lookups for an IP address to sync the `srcIP` variable. In case of _any failure or unsetting_ of the contact URL, the code again defines the source IP by getting the peer from the context.

#### Update on the publisher address:
The `cache.go` file was checking if the publisher address set by the docker-compose file contains `:` char to decide whether to use this value or not. This means that the publisher's address must be defined without a port to be able to get consumed, and this would make the publisher **unreachable**. Therefore, a similar procedure as above is followed to use the publisher address set by docker-compose file.

#### Update on the docker-compose file:
The predefined ports of caches have been changed to be able to run **multiple caches** concurrently and to make them **reachable**. And also, I've put the comments on the relevant parts to clarify how the components work, and of course, how the caches get reachable.

I propose to use squash and merge if this passes the review.