### PR TITLE
Enable secure communication with TLS

### DIFF
--- a/bootstrap/server.go
+++ b/bootstrap/server.go
@@ -83,8 +83,9 @@ type bootstrapServer struct {
 var _ common.StarterShutdowner = (*bootstrapServer)(nil)
 
 func newBootstrapServer(l *logrus.Logger, b *Bootstrapd, db *sql.DB, conf *ConfigFile) (*bootstrapServer, error) {
-	grpcServer := common.NewDBGRPCServer(db)
+	grpcServer := common.NewDBGRPCServer(conf.Insecure, db)
 	ccmsg.RegisterNodeBootstrapdServer(grpcServer, &grpcBootstrapServer{bootstrap: b})
+	grpc_prometheus.EnableHandlingTimeHistogram()
 	grpc_prometheus.Register(grpcServer)
 
 	return &bootstrapServer{

--- a/bootstrap/server.go
+++ b/bootstrap/server.go
@@ -85,7 +85,8 @@ var _ common.StarterShutdowner = (*bootstrapServer)(nil)
 func newBootstrapServer(l *logrus.Logger, b *Bootstrapd, db *sql.DB, conf *ConfigFile) (*bootstrapServer, error) {
 	grpcServer := common.NewDBGRPCServer(conf.Insecure, db)
 	ccmsg.RegisterNodeBootstrapdServer(grpcServer, &grpcBootstrapServer{bootstrap: b})
-	grpc_prometheus.EnableHandlingTimeHistogram()
+	// Enable to observe gRPC latency
+	// grpc_prometheus.EnableHandlingTimeHistogram()
 	grpc_prometheus.Register(grpcServer)
 
 	return &bootstrapServer{

--- a/cache/server.go
+++ b/cache/server.go
@@ -121,7 +121,8 @@ func newClientProtocolServer(l *logrus.Logger, c *Cache, db *sql.DB, conf *Confi
 	grpcServer := common.NewDBGRPCServer(true, db)
 	ccmsg.RegisterClientCacheServer(grpcServer, &grpcClientCacheServer{cache: c})
 	ccmsg.RegisterPublisherCacheServer(grpcServer, &grpcPublisherCacheServer{cache: c})
-	grpc_prometheus.EnableHandlingTimeHistogram()
+	// Enable to observe gRPC latency
+	// grpc_prometheus.EnableHandlingTimeHistogram()
 	grpc_prometheus.Register(grpcServer)
 
 	httpServer := wrapGrpc(grpcServer)

--- a/cache/server.go
+++ b/cache/server.go
@@ -116,9 +116,12 @@ type clientProtocolServer struct {
 var _ common.StarterShutdowner = (*clientProtocolServer)(nil)
 
 func newClientProtocolServer(l *logrus.Logger, c *Cache, db *sql.DB, conf *ConfigFile, r *ledgerclient.Replicator) (*clientProtocolServer, error) {
-	grpcServer := common.NewDBGRPCServer(db)
+	// Cache security is currently delivered solely via the cachecash crypto
+	// guarantees. TLS certs will be added in future.
+	grpcServer := common.NewDBGRPCServer(true, db)
 	ccmsg.RegisterClientCacheServer(grpcServer, &grpcClientCacheServer{cache: c})
 	ccmsg.RegisterPublisherCacheServer(grpcServer, &grpcPublisherCacheServer{cache: c})
+	grpc_prometheus.EnableHandlingTimeHistogram()
 	grpc_prometheus.Register(grpcServer)
 
 	httpServer := wrapGrpc(grpcServer)

--- a/faucet/server.go
+++ b/faucet/server.go
@@ -73,7 +73,7 @@ type faucetServer struct {
 var _ common.StarterShutdowner = (*faucetServer)(nil)
 
 func newFaucetServer(l *logrus.Logger, f *Faucet, db *sql.DB, conf *ConfigFile) (*faucetServer, error) {
-	grpcServer := common.NewDBGRPCServer(db)
+	grpcServer := common.NewDBGRPCServer(conf.Insecure, db)
 	ccmsg.RegisterFaucetServer(grpcServer, &grpcFaucetServer{faucet: f})
 
 	return &faucetServer{

--- a/ledgerservice/server.go
+++ b/ledgerservice/server.go
@@ -98,7 +98,7 @@ type ledgerProtocolServer struct {
 var _ common.StarterShutdowner = (*ledgerProtocolServer)(nil)
 
 func newLedgerProtocolServer(l *logrus.Logger, s *LedgerService, db *sql.DB, conf *ConfigFile) (*ledgerProtocolServer, error) {
-	grpcServer := common.NewDBGRPCServer(db)
+	grpcServer := common.NewDBGRPCServer(conf.Insecure, db)
 	ccmsg.RegisterLedgerServer(grpcServer, &grpcLedgerServer{ledgerService: s})
 
 	httpServer := wrapGrpc(grpcServer)

--- a/log/client.go
+++ b/log/client.go
@@ -101,7 +101,8 @@ func NewClient(serverAddress, service, logDir string, debug, insecure bool, conf
 	}
 
 	if c.config.DeliverLogs {
-		conn, err := common.GRPCDial(serverAddress, insecure)
+		// LogPipe configuration for secure communication missing
+		conn, err := common.GRPCDial(serverAddress, true)
 		if err != nil {
 			return nil, err
 		}

--- a/log/server/logpipe.go
+++ b/log/server/logpipe.go
@@ -197,8 +197,8 @@ func (lp *LogPipe) Close(timeout time.Duration) error {
 // is stopped. It will close the `ready` channel you pass when ready to serve.
 func (lp *LogPipe) Boot(ready chan struct{}, db *sql.DB) error {
 	lp.connMutex.Lock()
-
-	lp.server = common.NewDBGRPCServer(db)
+	// LogPipe configuration for secure communication missing
+	lp.server = common.NewDBGRPCServer(true, db)
 	log.RegisterLogPipeServer(lp.server, lp)
 	lp.processContext, lp.processCancel = context.WithCancel(context.Background())
 

--- a/metricsproxy/server.go
+++ b/metricsproxy/server.go
@@ -83,9 +83,10 @@ type clientProtocolServer struct {
 var _ common.StarterShutdowner = (*clientProtocolServer)(nil)
 
 func newClientProtocolServer(l *logrus.Logger, conf *ConfigFile) (*clientProtocolServer, *grpcMetricsProxyServer, error) {
-	grpcServer := common.NewGRPCServer()
+	grpcServer := common.NewGRPCServer(conf.Insecure)
 	metricsServer := newGRPCMetricsProxyServer(l)
 	metrics.RegisterMetricsServer(grpcServer, metricsServer)
+	grpc_prometheus.EnableHandlingTimeHistogram()
 	grpc_prometheus.Register(grpcServer)
 
 	return &clientProtocolServer{

--- a/metricsproxy/server.go
+++ b/metricsproxy/server.go
@@ -86,7 +86,8 @@ func newClientProtocolServer(l *logrus.Logger, conf *ConfigFile) (*clientProtoco
 	grpcServer := common.NewGRPCServer(conf.Insecure)
 	metricsServer := newGRPCMetricsProxyServer(l)
 	metrics.RegisterMetricsServer(grpcServer, metricsServer)
-	grpc_prometheus.EnableHandlingTimeHistogram()
+	// Enable to observe gRPC latency
+	// grpc_prometheus.EnableHandlingTimeHistogram()
 	grpc_prometheus.Register(grpcServer)
 
 	return &clientProtocolServer{

--- a/publisher/server.go
+++ b/publisher/server.go
@@ -109,7 +109,8 @@ func newPublisherServer(l *logrus.Logger, p *ContentPublisher, db *sql.DB, conf 
 	grpcServer := common.NewDBGRPCServer(conf.Insecure, db)
 	ccmsg.RegisterCachePublisherServer(grpcServer, &grpcPublisherServer{publisher: p})
 	ccmsg.RegisterClientPublisherServer(grpcServer, &grpcPublisherServer{publisher: p})
-	grpc_prometheus.EnableHandlingTimeHistogram()
+	// Enable to observe gRPC latency
+	// grpc_prometheus.EnableHandlingTimeHistogram()
 	grpc_prometheus.Register(grpcServer)
 
 	httpServer := wrapGrpc(grpcServer, conf)

--- a/publisher/server.go
+++ b/publisher/server.go
@@ -106,9 +106,10 @@ type publisherServer struct {
 var _ common.StarterShutdowner = (*publisherServer)(nil)
 
 func newPublisherServer(l *logrus.Logger, p *ContentPublisher, db *sql.DB, conf *ConfigFile, r *ledgerclient.Replicator) (*publisherServer, error) {
-	grpcServer := common.NewDBGRPCServer(db)
+	grpcServer := common.NewDBGRPCServer(conf.Insecure, db)
 	ccmsg.RegisterCachePublisherServer(grpcServer, &grpcPublisherServer{publisher: p})
 	ccmsg.RegisterClientPublisherServer(grpcServer, &grpcPublisherServer{publisher: p})
+	grpc_prometheus.EnableHandlingTimeHistogram()
 	grpc_prometheus.Register(grpcServer)
 
 	httpServer := wrapGrpc(grpcServer, conf)


### PR DESCRIPTION
In this pull request, you find three main changes affecting the gRPC helpers, the sections using these helpers, and the Prometheus registering.

**How does it work?**

First, it requires to generate the **CA’s certificate** and the **CA’s private key**. Following that, the **server’s certificate** and the **server’s private key** for each daemon, except for caches and logpiped for now, by using the CA’s certificate and the CA’s private key. If the secure mode is enabled using the configuration, the server-side TLS implementation loads the **server’s certificate** and **private key** from the `/tls` directory.

The client-side TLS implementation works in the same way. If CacheCash runs in the secure mode, it loads the **CA certificate** that signed the server’s certificate. In this way, a client checks if it communicates with the right server by _verifying_ the server’s certificate.

**gRPC helpers:**

These are the functions that generate gRPC clients and servers for all the relevant daemons. Passing the **TLS credentials** into the options was **missing** before. I implement a part that allows passing a secure bool in these helpers. And the helpers load the relevant certificate and private key if the security mode is on. The responsible person for the deployment of CacheCash needs to generate the certificates and put them in the `/tls` directory.

**Note:** The file names to store the certificate and private keys at, it should be configurable.

There are comments in the relevant parts to show how to enable handling time histogram for gRPC services.

I propose to use a merge pull request if this passes the review.